### PR TITLE
Update Teresa Kubacka's profile image

### DIFF
--- a/index.html
+++ b/index.html
@@ -1717,7 +1717,7 @@
                       <figure class="image is-32x32" style="margin-right: 0;">
                         <a href="https://twitter.com/paniterka_ch">
                           <img class="is-rounded"
-                            src="https://pbs.twimg.com/profile_images/1208851896506765312/78g1qMp8_400x400.jpg"
+                            src="https://pbs.twimg.com/profile_images/1600822294888300544/ZhZZy2RZ_400x400.jpg"
                             alt="Teresa Kubacka">
                         </a>
                       </figure>


### PR DESCRIPTION
Hi there! I noticed a profile image was broken in the Lightning Talk section. I think I found the right link to update it but please doublecheck me :) 

I think this happened because the Twitter profile photo was changed - so it's possible more Twitter-based image links may break down the road as people update their Twitter profile photos. 